### PR TITLE
Pair directly with the lights, fixes #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.1.0
+- Added support for pairing direclty with the lights and using the remote as a toggle switch
+
 ## 1.0.0
 - Implemented as custom esphome component instead
 - Added brightness support

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ There is an [example here](example/) that you can look at.
 ### Note about multiple remotes
 I'm not sure how well this works with multiple remotes/paired to multiple lights. I only have one remote, so I have no way of testing it. I think it isn't the best experience since sending commands to the lights are blocking the sniffing of remotes.
 
+### Pairing directly with the lights and using the remote as a toggle switch
+1. To do this, you need to make your own 16 bit address and enable pairing:
+    ```yaml
+      light:
+        - platform: ikea_ansluta
+          name: 'IKEA Ansluta'
+          remote_address: <your remote address>
+          address: <your made up address>
+          pairing_enabled: true
+    ```
+1. Press and hold the remote. This will give you 5 seconds to enable the pairing mode on your light before the ESP sends the pairing command.
+1. You can now disable pairing mode and re-upload your config
+
 ## Upgrading from 0.1.x to 1.0.0
 1. Follow the how to use above, step 1-5
 1. Note the name and entity id and remote address for the old MQTT light in Home Assistant

--- a/custom_components/ikea_ansluta/ikea_ansluta.cpp
+++ b/custom_components/ikea_ansluta/ikea_ansluta.cpp
@@ -91,7 +91,8 @@ namespace esphome
     {
       return cmd == IkeaAnslutaCommand::OFF
         || cmd == IkeaAnslutaCommand::ON_50
-        || cmd == IkeaAnslutaCommand::ON_100;
+        || cmd == IkeaAnslutaCommand::ON_100
+        || cmd == IkeaAnslutaCommand::PAIR;
     }
 
     void IkeaAnsluta::register_listener(uint16_t remote_address, const std::function<void(IkeaAnslutaCommand)> &func)

--- a/custom_components/ikea_ansluta/light/__init__.py
+++ b/custom_components/ikea_ansluta/light/__init__.py
@@ -7,6 +7,7 @@ from .. import ikea_ansluta_ns, CONF_ANSLUTA_ID, IkeaAnsluta
 DEPENDENCIES = ['ikea_ansluta']
 
 CONF_REMOTE_ADDRESS = 'remote_address'
+CONF_ADDRESS = 'address';
 
 IkeaAnslutaLight = ikea_ansluta_ns.class_('IkeaAnslutaLight', light.LightOutput, cg.Component)
 
@@ -14,12 +15,16 @@ CONFIG_SCHEMA = cv.All(light.BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend({
     cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(IkeaAnslutaLight),
     cv.GenerateID(CONF_ANSLUTA_ID): cv.use_id(IkeaAnsluta),
     cv.Required(CONF_REMOTE_ADDRESS): cv.hex_uint16_t,
+    cv.Optional(CONF_ADDRESS): cv.hex_uint16_t,
 }).extend(cv.COMPONENT_SCHEMA))
 
 def to_code(config):
     var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
     yield cg.register_component(var, config)
     yield light.register_light(var, config)
+
+    if CONF_ADDRESS in config:
+        cg.add(var.set_address(config[CONF_ADDRESS]))
 
     cg.add(var.set_remote_address(config[CONF_REMOTE_ADDRESS]))
 

--- a/custom_components/ikea_ansluta/light/__init__.py
+++ b/custom_components/ikea_ansluta/light/__init__.py
@@ -8,6 +8,7 @@ DEPENDENCIES = ['ikea_ansluta']
 
 CONF_REMOTE_ADDRESS = 'remote_address'
 CONF_ADDRESS = 'address';
+CONF_PAIRING_ENABLED = 'pairing_enabled';
 
 IkeaAnslutaLight = ikea_ansluta_ns.class_('IkeaAnslutaLight', light.LightOutput, cg.Component)
 
@@ -16,6 +17,7 @@ CONFIG_SCHEMA = cv.All(light.BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend({
     cv.GenerateID(CONF_ANSLUTA_ID): cv.use_id(IkeaAnsluta),
     cv.Required(CONF_REMOTE_ADDRESS): cv.hex_uint16_t,
     cv.Optional(CONF_ADDRESS): cv.hex_uint16_t,
+    cv.Optional(CONF_PAIRING_ENABLED, default = False): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA))
 
 def to_code(config):
@@ -25,6 +27,9 @@ def to_code(config):
 
     if CONF_ADDRESS in config:
         cg.add(var.set_address(config[CONF_ADDRESS]))
+
+    if CONF_PAIRING_ENABLED in config:
+        cg.add(var.set_pairing_enabled(config[CONF_PAIRING_ENABLED]))
 
     cg.add(var.set_remote_address(config[CONF_REMOTE_ADDRESS]))
 

--- a/custom_components/ikea_ansluta/light/ikea_ansluta_light.cpp
+++ b/custom_components/ikea_ansluta/light/ikea_ansluta_light.cpp
@@ -86,7 +86,14 @@ namespace esphome
         return;
       }
 
-      this->remote_pressed_ = true;
+      if (!this->address_) {
+        // If we have a paired directly to the light, we don't want to ignore the new state
+        // Maybe rename the remote_pressed_ variable to something more descriptive...
+        this->remote_pressed_ = true;
+      } else {
+        call = this->state_->toggle();
+      }
+
       call.perform();
     }
 

--- a/custom_components/ikea_ansluta/light/ikea_ansluta_light.cpp
+++ b/custom_components/ikea_ansluta/light/ikea_ansluta_light.cpp
@@ -7,7 +7,8 @@ namespace esphome
   {
     static const char *TAG = "ikea_ansluta.light";
 
-    void IkeaAnslutaLight::setup() {
+    void IkeaAnslutaLight::setup()
+    {
       this->radio_->register_listener(this->remote_address_, [this](IkeaAnslutaCommand command) {
         ESP_LOGV(TAG, "Received command %#04x from radio", command);
         this->handle_remote_command(command);
@@ -16,9 +17,10 @@ namespace esphome
 
     void IkeaAnslutaLight::dump_config()
     {
-      ESP_LOGCONFIG(TAG, "Remote ID: %#04x", this->remote_address_);
-      if (address_.has_value())
+      ESP_LOGCONFIG(TAG, "Remote address: %#04x", this->remote_address_);
+      if (this->address_.has_value())
         ESP_LOGCONFIG(TAG, "Address: %#04x", *this->address_);
+      ESP_LOGCONFIG(TAG, "Pairing enabled: %s", this->pairing_enabled_ ? "true" : "false");
     }
 
     light::LightTraits IkeaAnslutaLight::get_traits()
@@ -28,7 +30,8 @@ namespace esphome
       return traits;
     }
 
-    void IkeaAnslutaLight::setup_state(light::LightState *state) {
+    void IkeaAnslutaLight::setup_state(light::LightState *state)
+    {
       state_ = state;
       state_->set_gamma_correct(0);
       state_->set_default_transition_length(0);
@@ -51,8 +54,14 @@ namespace esphome
         call.set_state(false);
         break;
       case IkeaAnslutaCommand::PAIR:
-        if (!this->address_.has_value())
+        if (!this->pairing_enabled_)
           return;
+
+        // TODO: Should be possible to validate this in the config?
+        if (!this->address_.has_value()) {
+          ESP_LOGW(TAG, "Pairing mode enabled, but address is not set!");
+          return;
+        }
 
         ESP_LOGI(TAG, "Waiting 5s before sending pairing commmand ...");
         // TODO: can this be fixed? I guess the delay messes it up
@@ -78,7 +87,8 @@ namespace esphome
     void IkeaAnslutaLight::write_state(light::LightState *state)
     {
       // Do not write state if set from remote
-      if (this->remote_pressed_) {
+      if (this->remote_pressed_)
+      {
         this->remote_pressed_ = false;
         return;
       }

--- a/custom_components/ikea_ansluta/light/ikea_ansluta_light.cpp
+++ b/custom_components/ikea_ansluta/light/ikea_ansluta_light.cpp
@@ -109,18 +109,17 @@ namespace esphome
       state->current_values_as_brightness(&brightness);
 
       // TODO: make threshold configurable
-      // TODO: refactor to use this->send_command()
       if (brightness > 0 && brightness <= 0.5)
       {
-        this->radio_->send_command(this->remote_address_, IkeaAnslutaCommand::ON_50);
+        this->send_command(IkeaAnslutaCommand::ON_50);
       }
       else if (brightness > 0.5)
       {
-        this->radio_->send_command(this->remote_address_, IkeaAnslutaCommand::ON_100);
+        this->send_command(IkeaAnslutaCommand::ON_100);
       }
       else
       {
-        this->radio_->send_command(this->remote_address_, IkeaAnslutaCommand::OFF);
+        this->send_command(IkeaAnslutaCommand::OFF);
       }
     }
   } // namespace ikea_ansluta

--- a/custom_components/ikea_ansluta/light/ikea_ansluta_light.cpp
+++ b/custom_components/ikea_ansluta/light/ikea_ansluta_light.cpp
@@ -36,6 +36,8 @@ namespace esphome
     void IkeaAnslutaLight::dump_config()
     {
       ESP_LOGCONFIG(TAG, "Remote ID: %#04x", this->remote_address_);
+      if (address_.has_value())
+        ESP_LOGCONFIG(TAG, "Address: %#04x", *this->address_);
     }
 
     light::LightTraits IkeaAnslutaLight::get_traits()

--- a/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
+++ b/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
@@ -15,9 +15,10 @@ namespace esphome
     public:
       void setup() override;
       void dump_config() override;
-      void set_radio(IkeaAnsluta *radio) { this->radio_ = radio; }
-      void set_remote_address(uint16_t address) { this->remote_address_ = address; }
-      void set_address(uint16_t address) { this->address_ = address; }
+      void set_radio(IkeaAnsluta *radio) { this->radio_ = radio; };
+      void set_remote_address(uint16_t address) { this->remote_address_ = address; };
+      void set_address(uint16_t address) { this->address_ = address; };
+      void set_pairing_enabled(bool allow) { this->pairing_enabled_ = allow; };
       light::LightTraits get_traits() override;
       void setup_state(light::LightState *state) override;
       void write_state(light::LightState *state) override;
@@ -27,6 +28,7 @@ namespace esphome
       bool remote_pressed_ = false;
       uint16_t remote_address_{};
       optional<uint16_t> address_{};
+      bool pairing_enabled_{false};
       light::LightState *state_{nullptr};
       void handle_remote_command(IkeaAnslutaCommand command);
       void send_command(IkeaAnslutaCommand command);

--- a/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
+++ b/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/ikea_ansluta/ikea_ansluta.h"
 #include "esphome/components/light/light_output.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome
 {
@@ -16,6 +17,7 @@ namespace esphome
       void dump_config() override;
       void set_radio(IkeaAnsluta *radio) { this->radio_ = radio; }
       void set_remote_address(uint16_t address) { this->remote_address_ = address; }
+      void set_address(uint16_t address) { this->address_ = address; }
       light::LightTraits get_traits() override;
       void setup_state(light::LightState *state) override;
       void write_state(light::LightState *state) override;
@@ -24,6 +26,7 @@ namespace esphome
       IkeaAnsluta *radio_;
       bool remote_pressed_ = false;
       uint16_t remote_address_{};
+      optional<uint16_t> address_{};
       light::LightState *state_{nullptr};
     };
 

--- a/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
+++ b/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
@@ -14,6 +14,7 @@ namespace esphome
     {
     public:
       void setup() override;
+      void loop() override;
       void dump_config() override;
       void set_radio(IkeaAnsluta *radio) { this->radio_ = radio; };
       void set_remote_address(uint16_t address) { this->remote_address_ = address; };
@@ -29,6 +30,7 @@ namespace esphome
       uint16_t remote_address_{};
       optional<uint16_t> address_{};
       bool pairing_enabled_{false};
+      uint32_t send_pairing_command_at_{0};
       light::LightState *state_{nullptr};
       void handle_remote_command(IkeaAnslutaCommand command);
       void send_command(IkeaAnslutaCommand command);

--- a/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
+++ b/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
@@ -28,9 +28,8 @@ namespace esphome
       uint16_t remote_address_{};
       optional<uint16_t> address_{};
       light::LightState *state_{nullptr};
-      uint8_t get_command_address() {
-        return this->address_.has_value() ? *this->address_ : this->remote_address_;
-      };
+      void handle_remote_command(IkeaAnslutaCommand command);
+      void send_command(IkeaAnslutaCommand command);
     };
 
   } // namespace ikea_ansluta

--- a/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
+++ b/custom_components/ikea_ansluta/light/ikea_ansluta_light.h
@@ -28,6 +28,9 @@ namespace esphome
       uint16_t remote_address_{};
       optional<uint16_t> address_{};
       light::LightState *state_{nullptr};
+      uint8_t get_command_address() {
+        return this->address_.has_value() ? *this->address_ : this->remote_address_;
+      };
     };
 
   } // namespace ikea_ansluta

--- a/example/ikea_ansluta_direct.yaml
+++ b/example/ikea_ansluta_direct.yaml
@@ -1,0 +1,35 @@
+esphome:
+  name: ikea_ansluta_example
+  platform: ESP8266
+  board: d1_mini
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  ap:
+    ssid: "Ikea Ansluta Fallback Hotspot"
+    password: !secret ap_password
+
+captive_portal:
+
+logger:
+
+api:
+
+ota:
+
+spi:
+  clk_pin: GPIO14
+  miso_pin: GPIO12
+  mosi_pin: GPIO13
+
+ikea_ansluta:
+  cs_pin: GPIO15
+
+light:
+  - platform: ikea_ansluta
+    name: 'IKEA Ansluta'
+    remote_address: 0x35c0
+    address: 0xdead
+    pairing_enabled: true


### PR DESCRIPTION
- [x] Config for address to pair as
- [x] Pair with light when remote sends pairing command
  - [x] Add config to allow pairing mode (too easy to send the pairing command by mistake)
  - [x] See if it's possible to fix the disconnect related to the delay
  - [ ] Validate that address is set if `pairing_enabled` using config validation instead of warning log
- [x] Use correct address when sending commands
- [x] toggle or cycle the state on remote commands

Problems found:
-  Rapidly clicking the remote doesn't work. The sending is blocking receiving commands from the remote (sending takes ~1 second now).
   I don't think I'll try to fix this now. For me the most important thing is having reliable commands sent from the remote. The remote will only turn the lights on and off anyways and how often do you do that fast?
  I might have a possible solution for this, but for now I'll leave it be.